### PR TITLE
Refactor json validation logic in test code

### DIFF
--- a/src/main/kotlin/io/github/raeperd/realworldspringbootkotlin/web/WebConfiguration.kt
+++ b/src/main/kotlin/io/github/raeperd/realworldspringbootkotlin/web/WebConfiguration.kt
@@ -1,11 +1,15 @@
 package io.github.raeperd.realworldspringbootkotlin.web
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializerProvider
 import io.github.raeperd.realworldspringbootkotlin.domain.JWTDeserializer
 import io.github.raeperd.realworldspringbootkotlin.web.jwt.HttpRequestMeta
 import io.github.raeperd.realworldspringbootkotlin.web.jwt.JWTAccessControlFilter
 import io.github.raeperd.realworldspringbootkotlin.web.jwt.JWTAuthenticationFilter
 import io.github.raeperd.realworldspringbootkotlin.web.jwt.JWTPayloadArgumentResolver
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -15,6 +19,9 @@ import org.springframework.http.HttpMethod.POST
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.time.Instant
+import java.time.format.DateTimeFormatterBuilder
+
 
 @Configuration
 class WebConfiguration : WebMvcConfigurer {
@@ -45,5 +52,17 @@ class WebConfiguration : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.addAll(arrayOf(JWTPayloadArgumentResolver(), ArticleQueryParamArgumentResolver()))
+    }
+
+    @Bean
+    fun addCustomTimeSerialization(): Jackson2ObjectMapperBuilderCustomizer? {
+        return Jackson2ObjectMapperBuilderCustomizer { builder ->
+            builder.serializerByType(Instant::class.java, object : JsonSerializer<Instant?>() {
+                private val formatter = DateTimeFormatterBuilder().appendInstant(3).toFormatter()
+                override fun serialize(instant: Instant?, generator: JsonGenerator, provider: SerializerProvider) {
+                    generator.writeString(formatter.format(instant))
+                }
+            })
+        }
     }
 }

--- a/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/ArticleFavoriteIntegrationTest.kt
+++ b/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/ArticleFavoriteIntegrationTest.kt
@@ -24,12 +24,13 @@ class ArticleFavoriteIntegrationTest(
     fun `when post get delete articles favorite expect return valid response`() {
         val celeb = mockMvc.postMockUser("celeb")
         val postDto = createArticlePostDto("Title to favorite")
-        mockMvc.postArticles(celeb, postDto)
+        val articleDto = mockMvc.postArticles(celeb, postDto)
             .andExpect { status { isCreated() } }
             .andReturnResponseBody<ArticleModel>().article
 
-        val articleDto = mockMvc.getArticlesBySlug(postDto.article.title.slugify())
-            .andReturnResponseBody<ArticleModel>().article
+        mockMvc.getArticlesBySlug(postDto.article.title.slugify())
+            .andReturnResponseBody<ArticleModel>()
+            .apply { assertThat(article).isEqualTo(articleDto) }
 
         val fan = mockMvc.postMockUser("fan")
         mockMvc.post("/articles/${articleDto.slug}/favorite") { withAuthToken(fan.token) }

--- a/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/UserIntegrationTest.kt
+++ b/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/UserIntegrationTest.kt
@@ -51,7 +51,7 @@ class UserIntegrationTest(
         mockMvc.postUsersLogin(email, password)
             .andExpect { status { isOk() } }
             .andReturnResponseBody<UserModel>().user
-            .apply { assertThat(this).isEqualTo(userDto) }
+            .apply { assertThat(this).isEqualTo(userDto.copy(token = this.token)) }
     }
 
     @Test

--- a/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/util/jackson/SingletonObjectMapper.kt
+++ b/src/test/kotlin/io/github/raeperd/realworldspringbootkotlin/util/jackson/SingletonObjectMapper.kt
@@ -3,26 +3,30 @@ package io.github.raeperd.realworldspringbootkotlin.util.jackson
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import java.time.Instant
+import java.time.format.DateTimeFormatterBuilder
 
 object SingletonObjectMapper : ObjectMapper() {
     init {
-        registerModule(
-            KotlinModule.Builder()
-                .withReflectionCacheSize(512)
-                .configure(KotlinFeature.NullToEmptyCollection, false)
-                .configure(KotlinFeature.NullToEmptyMap, false)
-                .configure(KotlinFeature.NullIsSameAsDefault, false)
-                .configure(KotlinFeature.SingletonSupport, false)
-                .configure(KotlinFeature.StrictNullChecks, false)
-                .build()
-        )
-        registerModule(JavaTimeModule())
+        registerKotlinModule()
+        registerModule(ISOTimeModule())
         configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         setSerializationInclusion(JsonInclude.Include.NON_NULL)
     }
 }
 
-fun <T> T.toJson(): String = SingletonObjectMapper.writeValueAsString(this)
+private class ISOTimeModule : SimpleModule() {
+    init {
+        addDeserializer(Instant::class.java, FractionKnowingInstantDeserializer())
+    }
+
+    private class FractionKnowingInstantDeserializer : InstantDeserializer<Instant>(
+        INSTANT,
+        DateTimeFormatterBuilder().appendInstant(-1).toFormatter()
+    )
+}
+
+fun Any.toJson(): String = SingletonObjectMapper.writeValueAsString(this)


### PR DESCRIPTION
No more jsonPath validations
By deserializing response, it is implicitly checked.
Additional fix on microseconds serializations